### PR TITLE
Set installation file correctly and re-use previously installed file.

### DIFF
--- a/src/installerbundle.h
+++ b/src/installerbundle.h
@@ -45,7 +45,10 @@ public:
   virtual QList<MOBase::PluginSetting> settings() const;
 
   virtual unsigned int priority() const override;
-  virtual bool isManualInstaller() const;
+  virtual bool isManualInstaller() const override;
+
+  virtual void onInstallationStart(QString const& archive, bool reinstallation, MOBase::IModInterface* currentMod) override;
+  virtual void onInstallationEnd(EInstallResult result, MOBase::IModInterface* newMod) override;
 
   virtual bool isArchiveSupported(std::shared_ptr<const MOBase::IFileTree> tree) const override;
   virtual EInstallResult install(MOBase::GuessedValue<QString> &modName,
@@ -62,6 +65,24 @@ private:
    * @return the entry, if one was found, or a null pointer.
    */
   std::vector<std::shared_ptr<const MOBase::FileTreeEntry>> findObjects(std::shared_ptr<const MOBase::IFileTree> tree) const;
+
+private:
+
+  MOBase::IOrganizer* m_Organizer;
+
+  // The archive being installed:
+  QString m_InstallationFile;
+
+  // Indicates if this installer was used during the installation process:
+  bool m_InstallerUsed;
+
+  // Contains the file installed (when multiple archives are present), or an
+  // empty string:
+  QString m_SelectedFile;
+
+  // Contains the file previously installed (when multiple archives are present), or an
+  // empty string:
+  QString m_PreviousFile;
 };
 
 


### PR DESCRIPTION
1. Correctly set the "installation file" in the `meta.ini` to point to the original archive (not the extracted one). This should have been fixed long ago but without the new callbacks it would have be a PITA.

2. When there are multiple archives bundled together, automatically re-install the previously installed one:
    - This only happens on actual re-installation and not when the user re-installs the same archive from the download tab. This is mandatory, otherwise there would be no way to install all the bundled archives.
    - There is a setting to disable the behavior if required.

1) is pretty great, but I would not bother that much with 2) since there are very few multi-bundle archives.

Closes https://github.com/ModOrganizer2/modorganizer/issues/1128